### PR TITLE
rubocopを導入して既存コードを規約に沿って修正した

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,8 @@
+AllCops:
+  TargetRubyVersion: 2.5.0
+
+Style/Documentation:
+  Enabled: false
+
+Metrics/LineLength:
+  Max: 200

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
-source "https://rubygems.org"
+# frozen_string_literal: true
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+source 'https://rubygems.org'
+
+git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in esa_archiver.gemspec
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,51 @@
+PATH
+  remote: .
+  specs:
+    esa_archiver (0.1.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    ast (2.4.0)
+    diff-lcs (1.3)
+    parallel (1.12.1)
+    parser (2.4.0.2)
+      ast (~> 2.3)
+    powerpack (0.1.1)
+    rainbow (3.0.0)
+    rake (10.5.0)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.1)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.1)
+    rubocop (0.52.1)
+      parallel (~> 1.10)
+      parser (>= 2.4.0.2, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.9.0)
+    unicode-display_width (1.3.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler (~> 1.16)
+  esa_archiver!
+  rake (~> 10.0)
+  rspec (~> 3.0)
+  rubocop
+
+BUNDLED WITH
+   1.16.1

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-require "bundler/setup"
-require "esa_archiver"
+require 'bundler/setup'
+require 'esa_archiver'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
@@ -10,5 +11,5 @@ require "esa_archiver"
 # require "pry"
 # Pry.start
 
-require "irb"
+require 'irb'
 IRB.start(__FILE__)

--- a/esa_archiver.gemspec
+++ b/esa_archiver.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "rubocop"
 end

--- a/esa_archiver.gemspec
+++ b/esa_archiver.gemspec
@@ -16,15 +16,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/Pegasus204/esa_archiver'
   spec.license       = 'MIT'
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise 'RubyGems 2.0 or newer is required to protect against ' \
-      'public gem pushes.'
-  end
-
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end

--- a/esa_archiver.gemspec
+++ b/esa_archiver.gemspec
@@ -1,37 +1,39 @@
 
-lib = File.expand_path("../lib", __FILE__)
+# frozen_string_literal: true
+
+lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "esa_archiver/version"
+require 'esa_archiver/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "esa_archiver"
+  spec.name          = 'esa_archiver'
   spec.version       = EsaArchiver::VERSION
-  spec.authors       = ["Pegasus204"]
-  spec.email         = ["ride.or.die.2215@gmail.com"]
+  spec.authors       = ['Pegasus204']
+  spec.email         = ['ride.or.die.2215@gmail.com']
 
-  spec.summary       = %q{Archive the esa post that a fixed period of time passed.}
-  spec.description   = %q{Archive the esa post that a fixed period of time passed.}
-  spec.homepage      = "https://github.com/Pegasus204/esa_archiver"
-  spec.license       = "MIT"
+  spec.summary       = 'Archive the esa post that a fixed period of time passed.'
+  spec.description   = 'Archive the esa post that a fixed period of time passed.'
+  spec.homepage      = 'https://github.com/Pegasus204/esa_archiver'
+  spec.license       = 'MIT'
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata["allowed_push_host"] = "TODO: Set to 'http://mygemserver.com'"
+    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
   else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
+    raise 'RubyGems 2.0 or newer is required to protect against ' \
+      'public gem pushes.'
   end
 
-  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
+  spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.bindir        = "exe"
+  spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
-  spec.require_paths = ["lib"]
+  spec.require_paths = ['lib']
 
-  spec.add_development_dependency "bundler", "~> 1.16"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rubocop"
+  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'rubocop'
 end

--- a/lib/esa_archiver.rb
+++ b/lib/esa_archiver.rb
@@ -1,4 +1,6 @@
-require "esa_archiver/version"
+# frozen_string_literal: true
+
+require 'esa_archiver/version'
 
 module EsaArchiver
   # Your code goes here...

--- a/lib/esa_archiver/version.rb
+++ b/lib/esa_archiver/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module EsaArchiver
-  VERSION = "0.1.0"
+  VERSION = '0.1.0'
 end

--- a/spec/esa_archiver_spec.rb
+++ b/spec/esa_archiver_spec.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 RSpec.describe EsaArchiver do
-  it "has a version number" do
+  it 'has a version number' do
     expect(EsaArchiver::VERSION).not_to be nil
   end
 
-  it "does something useful" do
+  it 'does something useful' do
     expect(false).to eq(true)
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,11 @@
-require "bundler/setup"
-require "esa_archiver"
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'esa_archiver'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
+  config.example_status_persistence_file_path = '.rspec_status'
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!


### PR DESCRIPTION
## :sparkles: 目的

rubocopを導入すると、コードを一定の規約に揃えることができる。
そのため導入し、既存のコードを規約に沿って修正する。

## :white_check_mark: テスト

Rubocopが通ることを確認した