### PR TITLE
Dockerで開発できるようにした

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ruby:2.5.0
+MAINTAINER Temma Fukaya <ride.or.die.2215@gmail.com>
+USER root
+
+ENV APP_ROOT /app
+RUN mkdir $APP_ROOT
+WORKDIR $APP_ROOT
+
+RUN apt-get update
+RUN echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen
+ENV LANG en_US.UTF-8
+
+COPY . .
+
+RUN gem install bundler --no-document
+RUN bundle install


### PR DESCRIPTION
## :sparkles: 目的

Dockerを使うとローカル環境を汚すことなく開発を行うことができる。
そのためDockerで開発できるようにする。

## :wrench: 実装

Dockerfileを追加する。

## :white_check_mark: テスト

`docker build -t esa_archiver .`を実行しコンテナが構築されることを確認した。
`docker run --rm -it -v "$PWD":/usr/tmp -w /usr/tmp esa_archiver bash -i -c 'bundle exec rubocop'`でrubocopを実行できることを確認した。