### PR TITLE
必ず通らないspecを削除した

### DIFF
--- a/spec/esa_archiver_spec.rb
+++ b/spec/esa_archiver_spec.rb
@@ -4,8 +4,4 @@ RSpec.describe EsaArchiver do
   it 'has a version number' do
     expect(EsaArchiver::VERSION).not_to be nil
   end
-
-  it 'does something useful' do
-    expect(false).to eq(true)
-  end
 end


### PR DESCRIPTION
## :sparkles: 目的

`bundle gem`コマンドでgemの土台を作成すると必ず落ちるspecが追加される。
これは開発の邪魔なので削除する。
 
## :white_check_mark: テスト

テストが全て通ることを確認した。