### PR TITLE
bin/consoleのshellをirbからpryにした

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,11 +7,16 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
+    coderay (1.1.2)
     diff-lcs (1.3)
+    method_source (0.9.0)
     parallel (1.12.1)
     parser (2.4.0.2)
       ast (~> 2.3)
     powerpack (0.1.1)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     rainbow (3.0.0)
     rake (10.5.0)
     rspec (3.7.0)
@@ -43,6 +48,7 @@ PLATFORMS
 DEPENDENCIES
   bundler (~> 1.16)
   esa_archiver!
+  pry
   rake (~> 10.0)
   rspec (~> 3.0)
   rubocop

--- a/bin/console
+++ b/bin/console
@@ -7,9 +7,8 @@ require 'esa_archiver'
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
 
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
+require 'pry'
+Pry.start
 
-require 'irb'
-IRB.start(__FILE__)
+# require 'irb'
+# IRB.start(__FILE__)

--- a/esa_archiver.gemspec
+++ b/esa_archiver.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop'


### PR DESCRIPTION
## :sparkles: 目的

bin/consoleが起動するシェルは標準ではirbだが、pryはirbの機能を拡張してくれていて使いやすいのでそちらに変更する。

## :white_check_mark: テスト

`docker run --rm -it esa_archiver bash -i -c 'bin/console'`を実行してpryが開くことを確認した。