### PR TITLE
記事をアーカイブするユーザを記事の作成者にした

### DIFF
--- a/lib/esa_archiver/entities/esa_post.rb
+++ b/lib/esa_archiver/entities/esa_post.rb
@@ -2,7 +2,7 @@
 
 module EsaArchiver
   module Entities
-    EsaPost = Struct.new(:number, :category, :message) do
+    EsaPost = Struct.new(:number, :category, :message, :created_by) do
       def archived_category
         "Archived/#{category}"
       end

--- a/lib/esa_archiver/gateways/esa_client.rb
+++ b/lib/esa_archiver/gateways/esa_client.rb
@@ -33,7 +33,8 @@ module EsaArchiver
         Entities::EsaPost.new(
           raw['number'],
           raw['category'],
-          raw['message']
+          raw['message'],
+          raw['created_by']['screen_name']
         )
       end
     end

--- a/lib/esa_archiver/use_cases/archive.rb
+++ b/lib/esa_archiver/use_cases/archive.rb
@@ -10,7 +10,7 @@ module EsaArchiver
       def call(category, elapsed_days)
         esa_port.find_expired_posts(category, days_ago(elapsed_days)).map do |expired_post|
           expired_post.category = expired_post.archived_category
-          esa_port.update_post(expired_post, 'esa_bot')
+          esa_port.update_post(expired_post, expired_post.created_by)
           { expired_post.number => 'Archived' }
         end
       end

--- a/spec/factories/esa_post.rb
+++ b/spec/factories/esa_post.rb
@@ -5,5 +5,6 @@ FactoryBot.define do
     sequence :number
     category { 'path/to/post' }
     message 'esa_archiver[skip notice]'
+    created_by 'user1'
   end
 end

--- a/spec/gateways/esa_client_spec.rb
+++ b/spec/gateways/esa_client_spec.rb
@@ -33,8 +33,7 @@ RSpec.describe EsaArchiver::Gateways::EsaClient do
       { 'number' => post.number,
         'category' => post.category,
         'message' => post.message,
-        'created_by' => { 'screen_name' => post.created_by }
-      }
+        'created_by' => { 'screen_name' => post.created_by } }
     end
     let(:response) { double('response', body: body) }
 

--- a/spec/gateways/esa_client_spec.rb
+++ b/spec/gateways/esa_client_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe EsaArchiver::Gateways::EsaClient do
       { 'posts' => [
         'number' => post.number,
         'category' => post.category,
-        'message' => 'esa_archiver[skip notice]'
+        'message' => post.message,
+        'created_by' => { 'screen_name' => post.created_by }
       ] }
     end
     let(:response) { double('response', body: body) }
@@ -31,15 +32,17 @@ RSpec.describe EsaArchiver::Gateways::EsaClient do
     let(:body) do
       { 'number' => post.number,
         'category' => post.category,
-        'message' => 'esa_archiver[skip notice]' }
+        'message' => post.message,
+        'created_by' => { 'screen_name' => post.created_by }
+      }
     end
     let(:response) { double('response', body: body) }
 
-    subject { target.update_post(post, 'bot_user') }
+    subject { target.update_post(post, 'user1') }
 
     it 'return updated post' do
       allow(driver).to receive(:update_post)
-        .with(post.number, category: post.category, message: 'esa_archiver[skip notice]', updated_by: 'bot_user')
+        .with(post.number, category: post.category, message: post.message, updated_by: post.created_by)
         .and_return(response)
       expect(subject).to eq(post)
     end

--- a/spec/use_cases/archive_spec.rb
+++ b/spec/use_cases/archive_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe EsaArchiver::UseCases::Archive do
       expect(esa_client).to receive(:update_post)
         .with(
           have_attributes(number: posts[post_no].number,
-                          category: 'Archived/path/to/post'), 'esa_bot'
+                          category: 'Archived/path/to/post'), 'user1'
         ).and_return(posts[post_no])
     end
   end


### PR DESCRIPTION
## :sparkles: 目的

これまで、`esa_bot`が記事のアーカイブを行っていたが、Web画面右上の通知欄に大量に通知がきてつらい。
これを解決する。
 
### :camera: スクリーンショット

記事の作成者が記事をアーカイブしたことにできている図
![screen_shot_2018-03-07_at_15_34_29](https://user-images.githubusercontent.com/23367170/37077199-3b8a8f4a-221d-11e8-8cd3-2499ccbf31ce.png)

## :muscle: 方針

esaチームの管理者権限を持つユーザのアクセストークンは、`esa_bot`以外のユーザになりすますことができる機能を使って、アーカイブを行うユーザを記事の作成者とした。

## :white_check_mark: テスト

なぜかローカルでテストできなかったので、Heroku上で実際にタスクを実行してテストした。
記事の作成者がアーカイブした履歴になっていることを確認した。