### PR TITLE
Dockerfileとdocker-composeでワークディレクトリがずれていたので修正した

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,10 @@
 FROM ruby:2.5.0
 MAINTAINER Temma Fukaya <ride.or.die.2215@gmail.com>
 USER root
-
-ENV APP_ROOT /app
-RUN mkdir $APP_ROOT
-WORKDIR $APP_ROOT
+WORKDIR /app
 
 RUN apt-get update
 RUN echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen
 ENV LANG en_US.UTF-8
 
-COPY . .
-
 RUN gem install bundler --no-document
-RUN bundle install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,12 @@
-version: "2"
+version: "3"
 services:
   app:
     build: .
     volumes:
-      - .:/src
+      - .:/app
+      - bundle-data:/usr/local/bundle/
     command: bash -c 'bundle install && bundle exec thor posts:archive'
+
+volumes:
+  bundle-data:
+    driver: local


### PR DESCRIPTION
## :sparkles: 目的

コードを修正してもdocker-composeコンテナに反映されていなかった。
これを解決する。
 
## :muscle: 方針

以下の理由でdocker-compose内のコンテナに反映されていなかった。

* `Dockerfile`でワークディレクトリは `/app`
* `docker-compose.yml`でワークディレクトリは `/src`

これを `/app`に統一する。

## :white_check_mark: テスト

`bin/console`にコードを追記して、`docker-compose run --rm app bash -ic 'bin/console'`をしたときに、追記したコードが読み込まれていることを確認した。