### PR TITLE
メッセージレベルがerrorでは不適切だったのでinfoにした

### DIFF
--- a/lib/esa_archiver/gateways/esa_client.rb
+++ b/lib/esa_archiver/gateways/esa_client.rb
@@ -25,8 +25,8 @@ module EsaArchiver
         if no_error?(response)
           to_post(response.body)
         else
-          logger.error "Post No.#{post.number} has error received #{response.body}"
-          logger.error 'Retry archiving post as esa_bot'
+          logger.info "Post No.#{post.number} has error received #{response.body}"
+          logger.info 'Retry archiving post as esa_bot'
           update_post(post, 'esa_bot')
         end
       end


### PR DESCRIPTION
## :sparkles: 目的

Heroku Papertailからエラー発生通知のメールがきていたが、通知されるべきでないエラーであった。
これを解決する。
 
## :muscle: 方針

LoggerのメッセージレベルをERRORとしていたが、INFOとする。

## :white_check_mark: テスト

INFOレベルでメッセージが表示されることを確認した。

## :speech_balloon: 相談

 * 書いてみたけど自信がないところとか
