### PR TITLE
CircleCI2.0でテストできるようにした

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,36 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/ruby:2.5.0-node
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - esa-archiver-{{ checksum "Gemfile.lock" }}
+            - esa-archiver-
+
+      - run:
+          name: Bundle Install
+          command: bundle check || bundle install
+
+      - save_cache:
+          key: esa-archiver-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
+
+      - run:
+          name: Rubocop
+          command: bundle exec rubocop
+
+      - run:
+          name: Run rspec in parallel
+          command: |
+            bundle exec rspec --profile 10 \
+                              --format progress \
+                              $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+
+      - store_test_results:
+          path: test_results


### PR DESCRIPTION
## :sparkles: 目的

CircleCI 1.0でテストしていたので、CircleCI 2.0に移行する。
 
## :muscle: 方針

- `.circleci/config.yml`に設定ファイルを作成する

## :white_check_mark: テスト

テストがCircleCI 2.0で行われることを確認した。
落ちているテストの対応は別PRで行う。