### PR TITLE
:fire: remove bundler dependency

### DIFF
--- a/esa_archiver.gemspec
+++ b/esa_archiver.gemspec
@@ -26,7 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'dotenv'
   spec.add_runtime_dependency 'esa'
   spec.add_runtime_dependency 'thor'
-  spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'factory_bot'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rake', '~> 12.3'


### PR DESCRIPTION
## :sparkles: 目的

Ruby:2.6.0からbundlerはRuby本体に内包されたので依存gemから削除する。
 
## :muscle: 方針

- gemspecファイルからbundlerを削除

## :white_check_mark: テスト

テストが通ることを確認した。