### PR TITLE
update: deplicate Ruby:2.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,10 +64,6 @@ workflows:
   test:
     jobs:
       - test:
-          name: "test-ruby24"
-          ruby-version: "2.4.7"
-
-      - test:
           name: "test-ruby25"
           ruby-version: "2.5.6"
 


### PR DESCRIPTION
## :sparkles: 目的

ActiveSupport:6.0.0対応のためRuby:2.4をサポート外にする

## :muscle: 方針

Ruby:2.4をサポート対象外にする

## :white_check_mark: テスト

CIが通ることを確認した