### PR TITLE
update Ruby to latest version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,8 +70,8 @@ workflows:
     jobs:
       - test:
           name: "test-ruby25"
-          ruby-version: "2.5.6"
+          ruby-version: "2.5.7"
 
       - test:
           name: "test-ruby26"
-          ruby-version: "2.6.4"
+          ruby-version: "2.6.5"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.6.3-stretch
+FROM ruby:2.6.5-stretch
 MAINTAINER Temma Fukaya <ride.or.die.2215@gmail.com>
 USER root
 WORKDIR /app
@@ -8,4 +8,5 @@ RUN apt-get update
 RUN echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen
 ENV LANG en_US.UTF-8
 
+RUN gem install bundler:2.0.2
 RUN bundle install


### PR DESCRIPTION
## :sparkles: 目的

Rubyを最新版にアップデートした

## :muscle: 方針

- Dockerでビルド時にbundler:2.0.2をインストールするようにした
- Ruby:2.6.5にアップデートした
- CircleCIで利用するRubyバージョンを`2.6.5`と`2.5.7`にした

## :white_check_mark: テスト

テストが通ることを確認した