### PR TITLE
CircleCIのテストにRuby 2.7を追加した

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,3 +75,7 @@ workflows:
       - test:
           name: "test-ruby26"
           ruby-version: "2.6.5"
+
+      - test:
+          name: "test-ruby27"
+          ruby-version: "2.7.0-preview1"


### PR DESCRIPTION
## :sparkles: 目的

CircleCIのテストにRuby 2.7を追加する

## :white_check_mark: テスト

テストが通ることを祈る